### PR TITLE
Clean up temporary volumes and orphaned containers on the node

### DIFF
--- a/vantage6-node/tests/docker/test_volume_cleanup.py
+++ b/vantage6-node/tests/docker/test_volume_cleanup.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for the temporary-volume and orphaned-resource cleanup logic in
+``DockerManager``.
+
+These tests construct a ``DockerManager`` without running its heavy
+``__init__`` (which would talk to the Docker daemon). Only the attributes the
+methods under test rely on are set up, and the Docker SDK is mocked.
+"""
+
+from threading import Lock, Thread
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from docker.errors import APIError, NotFound
+
+from vantage6.node.docker.docker_manager import APPNAME, DockerManager
+
+
+def _task(vol_name):
+    """Build a stand-in for a finished DockerTaskManager."""
+    return SimpleNamespace(tmp_vol_name=vol_name)
+
+
+class TestVolumeRefcount(TestCase):
+    """Reference-counted removal of shared temporary volumes."""
+
+    def setUp(self):
+        # Build the manager without invoking __init__.
+        self.mgr = DockerManager.__new__(DockerManager)
+        self.mgr._volume_refcounts = {}
+        self.mgr._volume_lock = Lock()
+        self.mgr.log = MagicMock()
+        self.mgr.docker = MagicMock()
+        # Isolate the refcount logic from the real create_volume/Docker.
+        self.mgr.create_volume = MagicMock()
+        self.volume = MagicMock()
+        self.mgr.docker.volumes.get.return_value = self.volume
+
+    def test_reserve_increments_and_creates_volume(self):
+        self.mgr._reserve_volume("v1")
+
+        self.assertEqual(self.mgr._volume_refcounts["v1"], 1)
+        self.mgr.create_volume.assert_called_once_with("v1")
+
+    def test_single_user_volume_is_removed_on_release(self):
+        self.mgr._reserve_volume("v1")
+
+        self.mgr._try_remove_tmp_volume(_task("v1"))
+
+        self.assertNotIn("v1", self.mgr._volume_refcounts)
+        self.mgr.docker.volumes.get.assert_called_once_with("v1")
+        self.volume.remove.assert_called_once_with()
+
+    def test_shared_volume_removed_only_after_last_release(self):
+        # A parent task and its child share one job_id volume.
+        self.mgr._reserve_volume("shared")
+        self.mgr._reserve_volume("shared")
+        self.assertEqual(self.mgr._volume_refcounts["shared"], 2)
+
+        # First task finishes: volume must be kept.
+        self.mgr._try_remove_tmp_volume(_task("shared"))
+        self.assertEqual(self.mgr._volume_refcounts["shared"], 1)
+        self.mgr.docker.volumes.get.assert_not_called()
+        self.volume.remove.assert_not_called()
+
+        # Last task finishes: volume is now removed.
+        self.mgr._try_remove_tmp_volume(_task("shared"))
+        self.assertNotIn("shared", self.mgr._volume_refcounts)
+        self.mgr.docker.volumes.get.assert_called_once_with("shared")
+        self.volume.remove.assert_called_once_with()
+
+    def test_release_without_volume_name_is_noop(self):
+        self.mgr._try_remove_tmp_volume(_task(None))
+
+        self.mgr.docker.volumes.get.assert_not_called()
+        self.assertEqual(self.mgr._volume_refcounts, {})
+
+    def test_in_use_volume_is_not_deleted_and_error_is_swallowed(self):
+        # Docker refusing removal ("volume in use") is the final backstop that
+        # guarantees a working volume is never deleted.
+        self.volume.remove.side_effect = APIError("volume is in use")
+        self.mgr._reserve_volume("v1")
+
+        # Must not raise.
+        self.mgr._try_remove_tmp_volume(_task("v1"))
+
+        self.volume.remove.assert_called_once_with()
+        self.assertNotIn("v1", self.mgr._volume_refcounts)
+
+    def test_missing_volume_on_release_is_swallowed(self):
+        self.mgr.docker.volumes.get.side_effect = NotFound("no such volume")
+        self.mgr._reserve_volume("v1")
+
+        # Must not raise even though the volume is already gone.
+        self.mgr._try_remove_tmp_volume(_task("v1"))
+
+        self.assertNotIn("v1", self.mgr._volume_refcounts)
+
+    def test_release_of_unreserved_volume_does_not_go_negative(self):
+        self.mgr._try_remove_tmp_volume(_task("never-reserved"))
+
+        # No negative counts should linger in the bookkeeping.
+        self.assertNotIn("never-reserved", self.mgr._volume_refcounts)
+
+    def test_concurrent_reserve_release_ends_consistent(self):
+        # Each thread does exactly one reserve and one release of the same
+        # volume. Because the lock serialises every reserve/release, the final
+        # reference count must net to zero regardless of interleaving.
+        errors = []
+
+        def _churn():
+            try:
+                self.mgr._reserve_volume("shared")
+                self.mgr._try_remove_tmp_volume(_task("shared"))
+            except Exception as exc:  # noqa: BLE001 - record for assertion
+                errors.append(exc)
+
+        threads = [Thread(target=_churn) for _ in range(50)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(errors, [])
+        self.assertNotIn("shared", self.mgr._volume_refcounts)
+
+
+class TestCreateVolume(TestCase):
+    """create_volume must be idempotent so reserving a shared volume is safe."""
+
+    def setUp(self):
+        self.mgr = DockerManager.__new__(DockerManager)
+        self.mgr.log = MagicMock()
+        self.mgr.docker = MagicMock()
+
+    def test_creates_volume_when_missing(self):
+        self.mgr.docker.volumes.get.side_effect = NotFound("no such volume")
+
+        self.mgr.create_volume("v1")
+
+        self.mgr.docker.volumes.create.assert_called_once_with("v1")
+
+    def test_is_idempotent_when_volume_exists(self):
+        self.mgr.docker.volumes.get.return_value = MagicMock()
+
+        self.mgr.create_volume("v1")
+
+        self.mgr.docker.volumes.create.assert_not_called()
+
+
+class TestRemoveOrphanedVolumes(TestCase):
+    """Startup sweep of leftover temporary volumes."""
+
+    def setUp(self):
+        self.mgr = DockerManager.__new__(DockerManager)
+        self.mgr.log = MagicMock()
+        self.mgr.docker = MagicMock()
+        self.mgr.ctx = SimpleNamespace(name="aioc-sl-train", scope="user")
+
+    def _volume(self, name, remove_error=None):
+        vol = MagicMock()
+        vol.name = name
+        if remove_error is not None:
+            vol.remove.side_effect = remove_error
+        return vol
+
+    def test_only_matching_tmp_volumes_are_removed(self):
+        prefix = f"{APPNAME}-aioc-sl-train-user-"
+        tmp1 = self._volume(f"{prefix}70-tmpvol")
+        tmp2 = self._volume(f"{prefix}71-tmpvol")
+        data_vol = self._volume(f"{prefix}vol")  # persistent node data
+        squid_vol = self._volume(f"{prefix}squid-vol")  # persistent squid data
+        other_node = self._volume(f"{APPNAME}-other-user-5-tmpvol")
+        self.mgr.docker.volumes.list.return_value = [
+            tmp1,
+            tmp2,
+            data_vol,
+            squid_vol,
+            other_node,
+        ]
+
+        self.mgr._remove_orphaned_volumes()
+
+        tmp1.remove.assert_called_once_with()
+        tmp2.remove.assert_called_once_with()
+        # Persistent and other-node volumes must never be touched.
+        data_vol.remove.assert_not_called()
+        squid_vol.remove.assert_not_called()
+        other_node.remove.assert_not_called()
+
+    def test_in_use_tmp_volume_is_skipped_without_error(self):
+        prefix = f"{APPNAME}-aioc-sl-train-user-"
+        in_use = self._volume(f"{prefix}70-tmpvol", remove_error=APIError("in use"))
+        self.mgr.docker.volumes.list.return_value = [in_use]
+
+        # Must not raise even though Docker refuses removal.
+        self.mgr._remove_orphaned_volumes()
+
+        in_use.remove.assert_called_once_with()
+
+
+class TestRemoveOrphanedContainers(TestCase):
+    """Startup sweep of leftover algorithm/helper containers."""
+
+    def setUp(self):
+        self.mgr = DockerManager.__new__(DockerManager)
+        self.mgr.log = MagicMock()
+        self.mgr.docker = MagicMock()
+        self.mgr.node_name = "aioc-sl-train"
+
+    @patch("vantage6.node.docker.docker_manager.remove_container")
+    def test_leftover_containers_are_force_removed(self, remove_container):
+        c1 = MagicMock()
+        c1.name = "vantage6-aioc-sl-train-run-1"
+        c2 = MagicMock()
+        c2.name = "vantage6-aioc-sl-train-run-1-helper"
+        self.mgr.docker.containers.list.return_value = [c1, c2]
+
+        self.mgr._remove_orphaned_containers()
+
+        self.mgr.docker.containers.list.assert_called_once_with(
+            all=True,
+            filters={"label": ["node=aioc-sl-train"]},
+        )
+        self.assertEqual(remove_container.call_count, 2)
+        remove_container.assert_any_call(c1, kill=True)
+        remove_container.assert_any_call(c2, kill=True)
+
+    @patch("vantage6.node.docker.docker_manager.remove_container")
+    def test_no_containers_is_noop(self, remove_container):
+        self.mgr.docker.containers.list.return_value = []
+
+        self.mgr._remove_orphaned_containers()
+
+        remove_container.assert_not_called()

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -466,9 +466,10 @@ class Node:
             )
             return  # prevent starting the run if there is no token
 
-        # create a temporary volume for each job_id
+        # temporary volume name for this job_id; the volume itself is created
+        # (and reference-counted) inside DockerManager.run() once the task is
+        # actually going to start
         vol_name = self.ctx.docker_temporary_volume_name(task["job_id"])
-        self.__docker.create_volume(vol_name)
 
         # For some reason, if the key 'input' consists of JSON, it is
         # automatically marshalled? This causes trouble, so we'll serialize it

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -15,6 +15,7 @@ import docker
 import re
 import shutil
 
+from threading import Lock
 from typing import NamedTuple
 from pathlib import Path
 
@@ -24,6 +25,7 @@ from vantage6.common.docker.addons import (
     get_container,
     get_digest,
     get_image_name_wo_tag,
+    remove_container,
     running_in_docker,
 )
 from vantage6.common.globals import (
@@ -157,6 +159,15 @@ class DockerManager(DockerBaseManager):
         # keep track of the containers that have failed to start
         self.failed_tasks: list[DockerTaskManager] = []
 
+        # reference count per temporary volume name. A single tmp volume is
+        # shared by all tasks with the same job_id (e.g. a parent task and its
+        # child tasks). The volume is only removed once the last task using it
+        # has finished. The lock guards this dict because volumes are reserved
+        # on the main thread (__start_task) and released on the speaking worker
+        # thread (get_result).
+        self._volume_refcounts: dict[str, int] = {}
+        self._volume_lock = Lock()
+
         # before a task is executed it gets exposed to these policies
         self._policies = self._setup_policies(config)
 
@@ -194,6 +205,113 @@ class DockerManager(DockerBaseManager):
             self.log.warning(
                 "Algorithm logs and errors will be shared with the server."
             )
+
+        # remove any leftover containers from a previous (crashed) session
+        self._remove_orphaned_containers()
+        self._remove_orphaned_volumes()
+
+    def _remove_orphaned_containers(self) -> None:
+        """
+        Remove leftover algorithm and helper containers from a previous node
+        session that was not shut down cleanly.
+        """
+        orphans = self.docker.containers.list(
+            all=True,
+            filters={"label": [f"node={self.node_name}"]},
+        )
+        if orphans:
+            self.log.info(
+                "Found %d orphaned container(s) from a previous session, removing...",
+                len(orphans),
+            )
+        for container in orphans:
+            self.log.debug("Removing orphaned container: %s", container.name)
+            remove_container(container, kill=True)
+
+    def _remove_orphaned_volumes(self) -> None:
+        """
+        Remove temporary volumes belonging to this node that are no longer in
+        use by any running container.
+        """
+        # The volume naming pattern is: {APPNAME}-{name}-{scope}-{job_id}-tmpvol
+        prefix = f"{APPNAME}-{self.ctx.name}-{self.ctx.scope}-"
+        suffix = "-tmpvol"
+        for volume in self.docker.volumes.list():
+            if volume.name.startswith(prefix) and volume.name.endswith(suffix):
+                try:
+                    volume.remove()
+                    self.log.debug("Removed orphaned volume: %s", volume.name)
+                except docker.errors.APIError:
+                    # volume is still in use by a container
+                    self.log.debug(
+                        "Volume %s still in use, skipping", volume.name
+                    )
+
+    def _reserve_volume(self, vol_name: str) -> None:
+        """
+        Register that a task is about to use the temporary volume and make sure
+        the volume exists.
+
+        Reserving increments the reference count for the volume. Creating the
+        volume is done under the same lock so that a concurrent
+        ``_try_remove_tmp_volume`` on another thread cannot delete the volume
+        in the small window between creating it and reserving it.
+
+        Parameters
+        ----------
+        vol_name: str
+            Name of the temporary volume to reserve
+        """
+        with self._volume_lock:
+            self._volume_refcounts[vol_name] = (
+                self._volume_refcounts.get(vol_name, 0) + 1
+            )
+            self.create_volume(vol_name)
+
+    def _try_remove_tmp_volume(self, task: DockerTaskManager) -> None:
+        """
+        Release the temporary volume of a finished task and remove it once no
+        other task is using it anymore.
+
+        The reference count is decremented; the volume is only removed when the
+        count reaches zero (i.e. the last task sharing this job_id volume has
+        finished). Docker's own "volume in use" error is kept as a final
+        backstop so a volume that is somehow still mounted is never deleted.
+
+        Parameters
+        ----------
+        task: DockerTaskManager
+            The task whose temporary volume should be released
+        """
+        vol_name = getattr(task, "tmp_vol_name", None)
+        if not vol_name:
+            return
+
+        with self._volume_lock:
+            count = self._volume_refcounts.get(vol_name, 0) - 1
+            if count > 0:
+                self._volume_refcounts[vol_name] = count
+                self.log.debug(
+                    "Volume %s still in use (%d task(s) left), keeping",
+                    vol_name,
+                    count,
+                )
+                return
+
+            # last task using this volume has finished
+            self._volume_refcounts.pop(vol_name, None)
+            try:
+                volume = self.docker.volumes.get(vol_name)
+                volume.remove()
+                self.log.debug("Removed temporary volume: %s", vol_name)
+            except docker.errors.NotFound:
+                pass
+            except docker.errors.APIError:
+                # a container somehow still mounts the volume; leave it for the
+                # orphaned volume sweep on the next node startup
+                self.log.debug(
+                    "Could not remove volume %s, it may still be in use", vol_name
+                )
 
     def _set_database(self, databases: dict | list) -> None:
         """
@@ -638,6 +756,11 @@ class DockerManager(DockerBaseManager):
                     run_id=task.run_id, task_id=task.task_id, parent_id=task.parent_id
                 )
             )
+        # also cleanup any tasks that failed to start but may have partially
+        # created containers (e.g. helper containers)
+        while self.failed_tasks:
+            task = self.failed_tasks.pop()
+            task.cleanup()
         return run_ids_killed
 
     def cleanup(self) -> None:
@@ -738,6 +861,11 @@ class DockerManager(DockerBaseManager):
             write_run_context_file=self.write_run_context_file,
         )
 
+        # Reserve the tmp volume before the (potentially slow) image pull in
+        # task.run(). This guarantees the volume is not removed by a finishing
+        # sibling task while this task is still starting up.
+        self._reserve_volume(tmp_vol_name)
+
         # attempt to kick of the task. If it fails do to unknown reasons we try
         # again. If it fails permanently we add it to the failed tasks to be
         # handled by the speaking worker of the node
@@ -756,9 +884,11 @@ class DockerManager(DockerBaseManager):
                 self.log.exception(
                     f"Failed to start run {run_id} for an unknown reason. Retrying..."
                 )
+                task.cleanup()
                 time.sleep(1)  # add some time before retrying the next attempt
 
             except PermanentAlgorithmStartFail:
+                task.cleanup()
                 break
 
             attempts += 1
@@ -819,6 +949,9 @@ class DockerManager(DockerBaseManager):
             # Cleanup containers
             finished_task.cleanup()
 
+            # Remove temporary volume if no other task is using it
+            self._try_remove_tmp_volume(finished_task)
+
             # Retrieve results from file
             results = finished_task.get_results()
 
@@ -829,6 +962,8 @@ class DockerManager(DockerBaseManager):
         else:
             # at least one task failed to start
             finished_task = self.failed_tasks.pop()
+            finished_task.cleanup()
+            self._try_remove_tmp_volume(finished_task)
             logs = "Container failed. Check node logs for details"
             results = b""
 

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -283,6 +283,7 @@ class DockerTaskManager(DockerBaseManager):
         # `run_input` may be a clearer name in a future focused refactor.
         # The run-context helper already uses `run_input` terminology.
         self.docker_input = docker_input
+        self.tmp_vol_name = tmp_vol_name
         self.volumes = self._prepare_volumes(tmp_vol_name, token)
         self.log.debug("volumes: %s", self.volumes)
 


### PR DESCRIPTION
## Wat dit oplost

De node ruimt tijdelijke Docker-volumes (`*-tmpvol`) niet op wanneer een taak of child-taak klaar is. Bij succesvolle taken blijft er een dangling volume achter; bij mislukte, gecrashte of via een node-herstart onderbroken taken blijft ook de container staan, die het volume vasthoudt zodat `docker volume prune` het niet kan opruimen. Op drukke nodes loopt de schijf daardoor vol. Zie issue vantage6/vantage6#1825.

## Wat er verandert

- **Volume cleanup met reference counting.** Eén tmp-volume wordt gedeeld door alle taken met hetzelfde `job_id` (parent + children). Het volume wordt pas verwijderd als de laatste taak die het gebruikt klaar is. Reserveren en vrijgeven gebeuren onder een `Lock`, want reserveren gebeurt op de main-thread (`__start_task`) en vrijgeven op de speaking-worker-thread (`get_result`).
- **Container cleanup op alle paden.** Containers van mislukte taken, mislukte start-retries en permanent gefaalde starts worden nu ook opgeruimd, niet alleen bij succes.
- **Opruimen bij het opstarten.** Bij het starten van de node worden achtergebleven containers en tmp-volumes van een vorige (gecrashte) sessie verwijderd, gefilterd op het `node={node_name}`-label.

## Waarom dit veilig is

- Het verwijderen is precies wat `v6 node clean` al handmatig doet; dit automatiseert dat op de juiste momenten.
- Een volume wordt nooit verwijderd zolang de reference count > 0 is, en Docker's eigen "volume in use"-fout wordt als extra vangnet afgevangen. Een werkend volume kan dus niet weggegooid worden.
- Alleen `*-tmpvol`-volumes worden aangeraakt. Persistente volumes (`-vol`, `-squid-vol`) blijven met rust.
- De opstart-sweep draait vóór de workers starten, dus die kan alleen resten van een vorige proces raken, nooit een taak van het huidige proces.

## Tests

`vantage6-node/tests/docker/test_volume_cleanup.py` (14 tests): reference-count-levenscyclus, gedeeld parent/child-volume, in-use vangnet, idempotente `create_volume`, opstart-sweeps (inclusief dat persistente volumes met rust gelaten worden) en een concurrency-stresstest op de lock.

WIP — bedoeld voor de v4-lijn (`release/4.15`). Rollout via canary-node eerst.