### PR TITLE
Fix websocket handling that hangs the server and strands nodes

### DIFF
--- a/docs/server/diagnosing_loops.rst
+++ b/docs/server/diagnosing_loops.rst
@@ -70,6 +70,53 @@ triggers the first stall, which is still open. Ours coincided with
 ``no PONG received in 3 seconds`` and multi-megabyte blob transfers happening at
 the same moment.
 
+.. _server-node-mass-drop:
+
+Recognising a mass drop, and dating it
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When every node goes offline at once the useful question is not *that* they
+left but *when*, because the shape of the answer names the cause. Ask the API
+rather than the UI, which only shows the current state:
+
+.. code-block:: python
+
+    res = client.node.list(collaboration=<id>, per_page=100)
+    for n in sorted(res["data"], key=lambda x: str(x["last_seen"])):
+        print(n["id"], n["status"], n["last_seen"], n["name"])
+
+Read the spread between the first and the last ``last_seen``:
+
+* **All within a second or two.** The server dropped them. Look at the server
+  process itself: a restart, a redeploy, or a crash.
+* **Spread over several minutes.** A ping-timeout cascade. The nodes died one
+  by one as each missed its own ping deadline, which points at something that
+  blocked the server's event loop for a while rather than something that killed
+  it.
+* **Spread over hours, unrelated times.** Not one incident. Treat each node
+  separately.
+
+Then line the window up against what the platform was doing. A cascade that
+starts immediately after a large task finishes, while results are being
+collected and pushed to blob storage, is the signature described above.
+
+We observed exactly this: ten of ten nodes left over a six minute window that
+began about two minutes after a training task completed and ended seconds
+before the next one was submitted. The server stayed responsive throughout, at
+roughly 30 ms on ``/api/version``, which rules out the server being down and
+leaves the event loop being blocked as the working explanation.
+
+.. warning::
+
+    A responsive server does not mean a healthy platform. Check node presence
+    and whether a submitted task is actually being picked up. A task sitting in
+    ``pending`` with no ``started_at`` while ``/api/version`` answers instantly
+    is the combination to watch for.
+
+**Why they do not come back on their own** is section 2: the reconnect fix is
+node side. Until the nodes run it, a node that loses its session stays gone
+until someone restarts it, however healthy the server is.
+
 2. A node that thinks it is connected while the server disagrees
 ----------------------------------------------------------------
 

--- a/docs/server/diagnosing_loops.rst
+++ b/docs/server/diagnosing_loops.rst
@@ -121,8 +121,12 @@ because the task is complete, patches again, and so on.
     curl -s -H "Authorization: Bearer $TOKEN" $SERVER/api/run/<run_id> \
       | jq '{id, status, started_at, finished_at}'
 
-``status`` set and ``finished_at: null`` is the signature. A ``started_at`` in
-the very recent past for an old task means it is still going round.
+``status`` set and ``finished_at: null`` is the signature.
+
+Note that this one usually arrives in bursts rather than as a continuous loop.
+The node picks up its open runs on each sync cycle, fails on the same one, and
+then goes quiet until the next cycle or a restart. Poll ``started_at`` a minute
+apart: if it does not move, you are between bursts, not fixed.
 
 **Fix** shipped in this PR, node side: send ``finished_at`` explicitly when
 failing a run.

--- a/docs/server/diagnosing_loops.rst
+++ b/docs/server/diagnosing_loops.rst
@@ -117,6 +117,59 @@ leaves the event loop being blocked as the working explanation.
 node side. Until the nodes run it, a node that loses its session stays gone
 until someone restarts it, however healthy the server is.
 
+Silence is a diagnosis of its own
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A log full of errors is easier to read than a log with nothing in it, so this
+case is worth spelling out. **The absence of traffic is a stronger signal than
+the presence of errors**, because each of the failure modes on this page leaves
+a distinctive trace, and no trace at all rules all of them out.
+
+After a mass drop, count what each node still does:
+
+.. code-block:: bash
+
+    # HTTP: does the node still poll for work?
+    grep -c "state=open&node_id=<id>" server.log
+
+    # HTTP: does it still try to authenticate?
+    grep -c "login as node '<id>'" server.log
+
+    # websocket: does it send events the server cannot place?
+    grep -c "session that no longer exists" server.log
+
+Interpret the combination:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 70
+
+    * - What you see
+      - What it means
+    * - Repeated logins, or repeated ``state=open`` polls
+      - The node is alive and trying. Its HTTP path works, so the problem is
+        limited to the websocket. This is the case the fixes here address.
+    * - No HTTP, but ``session that no longer exists`` keeps appearing
+      - A ghost session. The node believes it is connected and is emitting into
+        the void. Section 2.
+    * - Nothing at all, from any of the three
+      - The node is not running, or cannot reach the server. Nothing on the
+        server side can help, because every recovery path in this codebase is
+        triggered by something the node sends.
+
+That last row is the one that catches people out. We hit it: over two hours,
+ten train nodes produced not a single request, not one login attempt, and not
+one event the server had to reject, while a test node on the same server
+connected and worked normally. A server that is healthy and quiet, with a task
+sitting in ``pending``, means the work has to happen at the nodes.
+
+.. important::
+
+    Every recovery mechanism described on this page is reactive. The server can
+    only close a connection that exists, and the node can only reconnect if its
+    process is running. Neither helps a node that has stopped. Before reaching
+    for a server-side fix, confirm the node is actually alive and talking.
+
 2. A node that thinks it is connected while the server disagrees
 ----------------------------------------------------------------
 
@@ -142,6 +195,26 @@ socket is actually connected and reconnects when it is not.
 **Important** that fix lives in the node, so it does nothing for a node that is
 already stuck and cannot be redeployed on demand. See section 4 for the
 stopgap.
+
+**The two halves only work together.** Neither side recovers a ghost session on
+its own, and it is worth knowing which link breaks if you deploy only one:
+
+1. The node's transport is up, so its client reports itself as connected and
+   keeps emitting pings. Nothing in the node notices anything is wrong.
+2. The server intercepts an incoming event it cannot place and closes the
+   underlying connection. **This is event driven**: it fires only because the
+   node sent something. A silent node is never reached.
+3. The node's client now reports itself as disconnected. It does not reconnect
+   by itself, for the reason given at the end of this page: a clean server-side
+   close leaves the client engine in a state where it treats the disconnect as
+   final.
+4. The node's ping worker sees the disconnected state, rebuilds the connection
+   with a fresh token, rejoins its rooms and resynchronises its task queue.
+
+Deploy only the server half and step 4 never happens: an old node ends its days
+logging that it is skipping pings. Deploy only the node half and step 2 never
+happens, so the node never learns it should reconnect. Both halves, and a node
+process that is actually running, are required.
 
 3. A run that is handed out forever
 -----------------------------------

--- a/docs/server/diagnosing_loops.rst
+++ b/docs/server/diagnosing_loops.rst
@@ -1,0 +1,184 @@
+.. _server-diagnosing-loops:
+
+Diagnosing retry loops
+======================
+
+The failure modes below all look the same from the outside: the server gets
+slow, nodes show up as offline, and the log fills with repeating lines. They
+have different causes and different fixes, and telling them apart takes about a
+minute if you know what to grep for.
+
+This page is written to be usable by someone who has never seen the codebase,
+including an AI assistant working from logs alone.
+
+.. note::
+
+    Every loop here shares one property: **the repeating line is a symptom, not
+    the cause**. Before changing anything, find out whether the repetition is a
+    client that cannot succeed, or a server that cannot answer. The counting
+    commands under each section are there to settle that question with a number
+    instead of an impression.
+
+The four-line triage
+--------------------
+
+Run these against a recent slice of the server log. The one that returns a big
+number tells you which section to read.
+
+.. code-block:: bash
+
+    # 1. dead sockets: the original outage
+    grep -c "Cannot send to sid" server.log
+
+    # 2. ghost sessions: node online, server does not know it
+    grep -c "is not connected to namespace" server.log
+
+    # 3. a run that can never finish
+    grep -c "attempts to generate a key for completed task" server.log
+
+    # 4. the temporary unknown-session guard misfiring
+    grep -c "closing its connection so it can identify itself" server.log
+
+A handful of any of these is normal. Hundreds per minute is a loop.
+
+1. Broadcasts to sockets that are gone
+--------------------------------------
+
+**Looks like** ``Cannot send to sid <id>``, repeated, with API latency climbing
+into seconds and nodes dropping off in groups.
+
+**Cause** ``on_connect`` stored the rooms it joined on the session object. When
+that attribute was missing at disconnect time an ``AttributeError`` escaped
+before python-socketio reached ``manager.disconnect()``, so the sid was never
+removed from any room. Every later broadcast then tried to write to a socket
+that no longer existed. Under load the event loop spends its time on dead
+sockets, HTTP requests time out, and the timeouts cause more disconnects, which
+create more stale sids.
+
+**Confirm** the same sid appears in ``Cannot send to sid`` long after that
+client disconnected:
+
+.. code-block:: bash
+
+    grep "Cannot send to sid" server.log | awk '{print $NF}' | sort | uniq -c | sort -rn | head
+
+**Fix** shipped in this PR: leave every room explicitly and tolerate a session
+that is already gone.
+
+**Note** this makes the server survive the condition. It does not explain what
+triggers the first stall, which is still open. Ours coincided with
+``no PONG received in 3 seconds`` and multi-megabyte blob transfers happening at
+the same moment.
+
+2. A node that thinks it is connected while the server disagrees
+----------------------------------------------------------------
+
+**Looks like** ``/tasks is not connected to namespace``, repeating at exactly
+the node's ping interval, while the node's own log is quiet and it believes it
+is online. The node stays offline in the UI and never recovers on its own.
+
+**Cause** the transport is alive but the server has no session for that client,
+so python-socketio drops every event before any handler runs. The ping that
+would mark the node online is dropped along with everything else. The node has
+no reason to reconnect, because from its point of view nothing failed.
+
+**Confirm** the interval between repeats is constant and matches the ping
+interval. A constant interval means a timer, not a retry with backoff:
+
+.. code-block:: bash
+
+    grep "is not connected to namespace" server.log | cut -c1-19 | uniq -c | tail -20
+
+**Fix** shipped in this PR, node side: the ping worker now checks whether the
+socket is actually connected and reconnects when it is not.
+
+**Important** that fix lives in the node, so it does nothing for a node that is
+already stuck and cannot be redeployed on demand. See section 4 for the
+stopgap.
+
+3. A run that is handed out forever
+-----------------------------------
+
+**Looks like** these three lines cycling for one node, for a task that finished
+long ago:
+
+.. code-block:: text
+
+    POST api/token/container
+    WARNING - Node <id> attempts to generate a key for completed task <task>
+    PATCH api/run/<run>
+
+**Cause** the server assigns ``finished_at`` from whatever the payload contains,
+including nothing at all, and it selects open runs on ``finished_at IS NULL``.
+A node that patches a run without that field therefore reopens it. The node
+fetches it again on the next sync, tries to obtain a container token, is refused
+because the task is complete, patches again, and so on.
+
+**Confirm** the run has a status but no finish time:
+
+.. code-block:: bash
+
+    curl -s -H "Authorization: Bearer $TOKEN" $SERVER/api/run/<run_id> \
+      | jq '{id, status, started_at, finished_at}'
+
+``status`` set and ``finished_at: null`` is the signature. A ``started_at`` in
+the very recent past for an old task means it is still going round.
+
+**Fix** shipped in this PR, node side: send ``finished_at`` explicitly when
+failing a run.
+
+**Clearing an existing one** is not possible through the API. ``PATCH
+/api/run/<id>`` with ``finished_at`` returns HTTP 500 for a user token, so an
+already-looping run keeps going until the node is updated. It is noisy rather
+than harmful, but it does generate continuous blob traffic, which is worth
+knowing if you are also chasing section 1.
+
+4. The unknown-session guard misfiring
+--------------------------------------
+
+This section only applies if you are running the temporary guard from
+``temp/socketio-abort-unknown-session``. It is not part of this PR.
+
+**Looks like** ``closing its connection so it can identify itself again`` with
+**the same client id** coming back every few seconds.
+
+**Cause** the guard is meant to abort a stale connection once so the client
+reconnects. The first version removed the socket from ``server.eio.sockets``
+immediately after asking engine.io to close it. Every later abort attempt on
+that client then raised ``KeyError``, which was swallowed, so the connection was
+never actually closed. The client kept its transport, had all of its events
+dropped including pings, and went offline. This took 9 of 10 nodes down.
+
+**Confirm** count distinct client ids against total aborts:
+
+.. code-block:: bash
+
+    grep "closing its connection" server.log \
+      | grep -o "Client [A-Za-z0-9_-]*" | sort | uniq -c | sort -rn | head
+
+Healthy: each id appears once or twice. Broken: one id with dozens of hits.
+
+**Fix** the corrected guard aborts a connection at most once, waits 30 seconds
+so a client still completing its handshake is left alone, and disables itself
+entirely if it fires more than 20 times in a minute. That last one matters: a
+guard that runs away is worse than the problem it solves.
+
+**Watch for** ``Disabling the unknown-session guard`` in the log. That is the
+circuit breaker tripping, and it means something systematic is wrong rather than
+a few stale clients.
+
+A note on clean disconnects
+---------------------------
+
+If you are tempted to solve any of this by disconnecting a client from the
+server, measure it first. In python-socketio the client only reconnects while
+
+.. code-block:: python
+
+    will_reconnect = self.reconnection and self.eio.state == 'connected'
+
+A clean server-side close leaves the client engine in state ``disconnected``, so
+the client treats it as final and never comes back. A polite disconnect strands
+the node permanently. This was verified against a real client on
+python-socketio 5.16.4 and engineio 4.13.4, and it is the reason the guard
+aborts the transport instead of closing it.

--- a/docs/server/index.rst
+++ b/docs/server/index.rst
@@ -22,3 +22,4 @@ server.
     configure
     permissions
     shell
+    diagnosing_loops

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -569,6 +569,10 @@ class Node:
             except Exception as e:
                 self.log.error("Listening thread had an exception")
                 self.log.exception(e)
+            # wait() returns immediately while the socket is down, so without a
+            # pause this loop would spin at full speed until it is restored.
+            if not self.socketIO.connected:
+                time.sleep(ERROR_RETRY_DELAY_SECONDS)
 
     def __speaking_worker(self) -> None:
         """
@@ -1084,10 +1088,22 @@ class Node:
                 container_name=container_name, config_alias=alias
             )
 
-    def connect_to_socket(self) -> None:
+    def connect_to_socket(self, exit_on_failure: bool = True) -> bool:
         """
         Create long-lasting websocket connection with the server. The
         connection is used to receive status updates, such as new tasks.
+
+        Parameters
+        ----------
+        exit_on_failure : bool
+            Whether to terminate the node when the connection cannot be
+            established. This is the desired behaviour on startup, but not
+            when reconnecting a node that is already running.
+
+        Returns
+        -------
+        bool
+            Whether the connection was established.
         """
         debug_mode = self.debug.get("socketio", False)
         if debug_mode:
@@ -1129,7 +1145,10 @@ class Node:
                     "Could not connect to the websocket channels, do you have a "
                     "slow connection?"
                 )
-                exit(1)
+                if exit_on_failure:
+                    exit(1)
+                self.socketIO.shutdown()
+                return False
             self.log.debug("Waiting for socket connection...")
             time.sleep(1)
             i += 1
@@ -1142,6 +1161,7 @@ class Node:
             "Starting thread to ping the server to notify this node is online."
         )
         self.socketIO.start_background_task(self.__socket_ping_worker)
+        return True
 
     def __socket_ping_worker(self) -> None:
         """
@@ -1156,7 +1176,18 @@ class Node:
                 if self.socketIO.connected:
                     self.socketIO.emit("ping", namespace="/tasks")
                 else:
-                    self.log.debug("SocketIO is not connected, skipping ping")
+                    # The socket.io client gives up permanently when the server
+                    # closes the connection, and it reuses the authorization
+                    # header from the original connect, which by now may hold an
+                    # expired token. Rebuilding the connection solves both: it
+                    # picks up the current token and restores the session, which
+                    # is what marks this node online again.
+                    self.log.warning("Socket connection lost, reconnecting")
+                    if self.connect_to_socket(exit_on_failure=False):
+                        self.log.info("Socket connection restored")
+                        self.sync_task_queue_with_server()
+                        # connect_to_socket() started a new ping worker
+                        return
             except Exception:
                 self.log.exception("Ping thread had an exception")
             # Wait before sending next ping

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -62,6 +62,7 @@ from vantage6.node.globals import (
     TIME_LIMIT_RETRY_CONNECT_NODE,
     TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET,
     DEFAULT_SOCKET_RECONNECTION_DELAY_MAX,
+    ERROR_RETRY_DELAY_SECONDS,
 )
 from vantage6.common.client.node_client import NodeClient
 from vantage6.node import proxy_server
@@ -641,6 +642,11 @@ class Node:
                 )
             except Exception:
                 self.log.exception("Speaking thread had an exception")
+                # Back off before looping again. `get_result()` normally blocks
+                # until a result is available, but if anything above it raises
+                # the loop restarts immediately, and the node then hammers the
+                # server as fast as it can.
+                time.sleep(ERROR_RETRY_DELAY_SECONDS)
 
     def __print_connection_error_logs(self):
         """Print error message when node cannot find the server"""

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -61,6 +61,7 @@ from vantage6.node.globals import (
     SLEEP_BTWN_NODE_LOGIN_TRIES,
     TIME_LIMIT_RETRY_CONNECT_NODE,
     TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET,
+    DEFAULT_SOCKET_RECONNECTION_DELAY_MAX,
 )
 from vantage6.common.client.node_client import NodeClient
 from vantage6.node import proxy_server
@@ -1077,8 +1078,24 @@ class Node:
         debug_mode = self.debug.get("socketio", False)
         if debug_mode:
             self.log.debug("Debug mode enabled for socketio")
+
+        # Nodes retry forever, but the delay between attempts is capped. With
+        # python-socketio's default cap of 5 seconds a fleet of nodes keeps a
+        # struggling server under constant reconnect load, which makes an
+        # outage harder to recover from.
+        reconnection_delay_max = self.config.get("socketio", {}).get(
+            "reconnection_delay_max", DEFAULT_SOCKET_RECONNECTION_DELAY_MAX
+        )
+        self.log.debug(
+            "Websocket reconnect backoff capped at %s seconds",
+            reconnection_delay_max,
+        )
+
         self.socketIO = SocketIO(
-            request_timeout=60, logger=debug_mode, engineio_logger=debug_mode
+            request_timeout=60,
+            reconnection_delay_max=reconnection_delay_max,
+            logger=debug_mode,
+            engineio_logger=debug_mode,
         )
 
         self.socketIO.register_namespace(NodeTaskNamespace("/tasks"))

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -458,10 +458,18 @@ class Node:
             self.log.error(
                 "Container token could not be obtained: %s", token.get("msg")
             )
+            # `finished_at` must be set explicitly: the server overwrites it with
+            # whatever the payload contains, and it selects open runs on
+            # `finished_at IS NULL`. Without it the run stays open, is handed out
+            # again on the next sync, and the node keeps asking for a token that
+            # can never be issued.
             self.client.run.patch(
                 id_=task_incl_run["id"],
                 data={
                     "status": TaskStatus.FAILED,
+                    "finished_at": datetime.datetime.now(
+                        datetime.timezone.utc
+                    ).isoformat(),
                     "log": "Could not obtain algorithm container token",
                 },
             )

--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -26,6 +26,18 @@ TIME_LIMIT_RETRY_CONNECT_NODE = 60 * 60 * 24 * 7  # i.e. 1 week
 # constant for waiting for the initial websocket connection
 TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET = 60
 
+# Upper bound for the exponential backoff between websocket reconnect attempts.
+# python-socketio defaults to 5 seconds, which means a fleet of nodes keeps
+# hammering a struggling server roughly every 5 seconds indefinitely. Nodes
+# still retry forever, just less aggressively. Override per node with
+# `socketio.reconnection_delay_max` in the node configuration file.
+#
+# Note that python-socketio adds only a fixed +/- 0.5 second of jitter on top
+# of this delay, so reconnect attempts stay roughly synchronised across a
+# collaboration. That is harmless for a handful of nodes, but a large fleet
+# would also need a higher `randomization_factor` to spread the load out.
+DEFAULT_SOCKET_RECONNECTION_DELAY_MAX = 60
+
 #
 #    VPN CONFIGURATION RELATED CONSTANTS
 #

--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -38,6 +38,11 @@ TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET = 60
 # would also need a higher `randomization_factor` to spread the load out.
 DEFAULT_SOCKET_RECONNECTION_DELAY_MAX = 60
 
+# Pause after an unexpected error in a worker loop that talks to the server.
+# Without it a failing loop retries as fast as the CPU allows, which turns one
+# broken run into a stream of requests.
+ERROR_RETRY_DELAY_SECONDS = 10
+
 #
 #    VPN CONFIGURATION RELATED CONSTANTS
 #

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -33,6 +33,9 @@ server_url = None
 # Number of times the request is retried before the proxy server gives up
 RETRY = 3
 
+# Seconds to wait between retries
+RETRY_DELAY = 1
+
 
 def get_method(method: str) -> callable:
     """
@@ -114,8 +117,9 @@ def make_request(
     method = get_method(method)
 
     # Forward the request to the central server. Retry when an exception is
-    # raised (e.g. timeout or connection error) or when the server gives an
-    # error code greater than 210
+    # raised (e.g. timeout or connection error) or when the server gives a
+    # server-side error code. Client errors (4xx) are returned as-is: the
+    # request is malformed or not permitted, so repeating it only adds load.
     url = f"{server_url}/{endpoint}"
     for i in range(RETRY):
         try:
@@ -138,6 +142,15 @@ def make_request(
                 if "application/json" in response.headers.get("Content-Type"):
                     log.debug(response.json().get("msg", "no description..."))
 
+                if 400 <= response.status_code < 500:
+                    # Retrying will produce the same answer, so hand the error
+                    # back to the caller instead of hammering the server.
+                    return response
+
+                # Back off before retrying a server-side error. Without this the
+                # retries are issued back to back.
+                sleep(RETRY_DELAY)
+
             else:
                 # Exit the retry loop because we have collected a valid
                 # response
@@ -150,7 +163,7 @@ def make_request(
                 url,
             )
             log.debug("Exception details: %s", traceback.format_exc())
-            sleep(1)
+            sleep(RETRY_DELAY)
 
     # if all attempts fail, raise an exception to be handled by its parent
     raise Exception("Proxy request failed")

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -310,6 +310,8 @@ class ServerApp:
         namespace = DefaultSocketNamespace("/tasks", socketio, self.metrics)
         socketio.on_namespace(namespace)
 
+        _disconnect_clients_with_unknown_session(socketio)
+
         return socketio
 
     def configure_flask(self) -> None:
@@ -952,6 +954,57 @@ class ServerApp:
     #                         response["msg"],
     #                     )
     #             # else: store already exists, no need to couple it again
+
+
+def _disconnect_clients_with_unknown_session(socketio: SocketIO) -> None:
+    """
+    Close connections the server has no session for.
+
+    A client can end up with a live transport while the server no longer holds a
+    session for it, for example after the websocket was closed server-side but
+    the TCP connection stayed up. python-socketio then drops every incoming
+    event with "None is not connected to namespace", before any handler runs.
+    That includes the ping handler, which is what would mark the node online
+    again, so the client keeps sending into the void and never recovers.
+
+    Closing the underlying connection turns this into an ordinary disconnect.
+    The client reconnects, identifies itself and rejoins its rooms, without
+    needing any change on the client side.
+
+    This overrides a private method of python-socketio (pinned at 5.16.4 through
+    flask-socketio 5.6.1). If that internal changes, the override is skipped and
+    the old behaviour returns.
+
+    Parameters
+    ----------
+    socketio: SocketIO
+        The Flask-SocketIO instance to patch.
+    """
+    server = getattr(socketio, "server", None)
+    original_handle_event = getattr(server, "_handle_event", None)
+    if server is None or original_handle_event is None:
+        log.warning(
+            "Could not install the unknown-session handler: clients whose "
+            "session is gone will keep sending events that go nowhere"
+        )
+        return
+
+    def handle_event(eio_sid, namespace, id, data):
+        sid = server.manager.sid_from_eio_sid(eio_sid, namespace)
+        if not server.manager.is_connected(sid, namespace):
+            log.info(
+                "Received an event on %s for a session that no longer exists; "
+                "closing the connection so the client reconnects",
+                namespace,
+            )
+            try:
+                server.eio.disconnect(eio_sid)
+            except Exception:
+                log.exception("Failed to close connection %s", eio_sid)
+            return
+        return original_handle_event(eio_sid, namespace, id, data)
+
+    server._handle_event = handle_event
 
 
 def run_server(config: str, system_folders: bool = True) -> ServerApp:

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -310,8 +310,6 @@ class ServerApp:
         namespace = DefaultSocketNamespace("/tasks", socketio, self.metrics)
         socketio.on_namespace(namespace)
 
-        _disconnect_clients_with_unknown_session(socketio)
-
         return socketio
 
     def configure_flask(self) -> None:
@@ -954,57 +952,6 @@ class ServerApp:
     #                         response["msg"],
     #                     )
     #             # else: store already exists, no need to couple it again
-
-
-def _disconnect_clients_with_unknown_session(socketio: SocketIO) -> None:
-    """
-    Close connections the server has no session for.
-
-    A client can end up with a live transport while the server no longer holds a
-    session for it, for example after the websocket was closed server-side but
-    the TCP connection stayed up. python-socketio then drops every incoming
-    event with "None is not connected to namespace", before any handler runs.
-    That includes the ping handler, which is what would mark the node online
-    again, so the client keeps sending into the void and never recovers.
-
-    Closing the underlying connection turns this into an ordinary disconnect.
-    The client reconnects, identifies itself and rejoins its rooms, without
-    needing any change on the client side.
-
-    This overrides a private method of python-socketio (pinned at 5.16.4 through
-    flask-socketio 5.6.1). If that internal changes, the override is skipped and
-    the old behaviour returns.
-
-    Parameters
-    ----------
-    socketio: SocketIO
-        The Flask-SocketIO instance to patch.
-    """
-    server = getattr(socketio, "server", None)
-    original_handle_event = getattr(server, "_handle_event", None)
-    if server is None or original_handle_event is None:
-        log.warning(
-            "Could not install the unknown-session handler: clients whose "
-            "session is gone will keep sending events that go nowhere"
-        )
-        return
-
-    def handle_event(eio_sid, namespace, id, data):
-        sid = server.manager.sid_from_eio_sid(eio_sid, namespace)
-        if not server.manager.is_connected(sid, namespace):
-            log.info(
-                "Received an event on %s for a session that no longer exists; "
-                "closing the connection so the client reconnects",
-                namespace,
-            )
-            try:
-                server.eio.disconnect(eio_sid)
-            except Exception:
-                log.exception("Failed to close connection %s", eio_sid)
-            return
-        return original_handle_event(eio_sid, namespace, id, data)
-
-    server._handle_event = handle_event
 
 
 def run_server(config: str, system_folders: bool = True) -> ServerApp:

--- a/vantage6-server/vantage6/server/websockets.py
+++ b/vantage6-server/vantage6/server/websockets.py
@@ -4,7 +4,7 @@ import datetime as dt
 
 from flask import request, session
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
-from flask_socketio import Namespace, emit, join_room, leave_room
+from flask_socketio import Namespace, emit, join_room, leave_room, rooms
 
 from vantage6.common import logger_name
 from vantage6.common.globals import AuthStatus
@@ -105,7 +105,11 @@ class DefaultSocketNamespace(Namespace):
             emit("sync", room=request.sid)
             # Add node to rooms and alert other clients of that
             self._add_node_to_rooms(auth)
-            self.__alert_node_status(online=True, node=auth)
+            self.__alert_node_status(
+                online=True,
+                node_info=self.__node_info(auth),
+                target_rooms=session.rooms,
+            )
         elif session.type == "user":
             self._add_user_to_rooms(auth)
 
@@ -163,42 +167,96 @@ class DefaultSocketNamespace(Namespace):
                     f"collaboration_{collab.id}_organization_" f"{user.organization.id}"
                 )
 
-    def on_disconnect(self) -> None:
+    def on_disconnect(self, reason: str | None = None) -> None:
         """
         Client that disconnects is removed from all rooms they were in.
 
         If nodes disconnect, their status is also set to offline and users may
         be alerted to that. Also, any information on the node (e.g.
         configuration) is removed from the database.
+
+        The socket session may no longer be populated at this point, for
+        instance when the server restarted while the client was connected. The
+        rooms are therefore read from Socket.IO rather than from ``session``,
+        and the whole body is guarded so that Socket.IO always gets to run its
+        own cleanup. If this handler raises, python-socketio never reaches
+        ``manager.disconnect()`` and the sid stays in every room, after which
+        the server keeps broadcasting to a socket that is gone.
+
+        Parameters
+        ----------
+        reason: str | None
+            Disconnect reason. Newer python-socketio passes this; accepted and
+            logged so that the handler does not fail with a TypeError.
         """
         if not self.__is_identified_client():
             self.log.debug("Client disconnected before identification")
             return
 
-        for room in session.rooms:
-            # self.__leave_room_and_notify(room)
+        try:
+            left_rooms = self.__leave_all_rooms()
+
+            auth = db.Authenticatable.get(session.auth_id)
+            if auth is None:
+                self.log.warning(
+                    "Disconnecting client %s has no authenticatable record",
+                    session.auth_id,
+                )
+                return
+
+            # Read every attribute needed later while the instance is still
+            # attached: auth.save() commits, which expires the attributes, and
+            # the scoped session may be cleared before a later lazy load.
+            is_node = getattr(session, "type", None) == "node"
+            node_info = self.__node_info(auth) if is_node else None
+
+            auth.status = AuthStatus.OFFLINE.value
+            auth.save()
+
+            # It appears to be necessary to use the root socketio instance
+            # otherwise events cannot be sent outside the current namespace.
+            # In this case, only events to '/tasks' can be emitted otherwise.
+            if is_node:
+                self.socketio.emit("node-status-changed", namespace="/admin")
+                self.__alert_node_status(
+                    online=False, node_info=node_info, target_rooms=left_rooms
+                )
+
+                # delete any data on the node stored on the server (e.g.
+                # configuration data)
+                try:
+                    self.__clean_node_data(auth)
+                except Exception:
+                    self.log.exception("Failed to clean node data on disconnect")
+
+            self.log.info("%s disconnected", getattr(session, "name", session.auth_id))
+        except Exception:
+            self.log.exception(
+                "Error while handling disconnect; continuing so that the socket "
+                "is still removed from its rooms"
+            )
+        finally:
+            # cleanup (e.g. database session)
+            self.__cleanup()
+
+    def __leave_all_rooms(self) -> list[str]:
+        """
+        Remove the disconnecting client from every room it joined.
+
+        Socket.IO is the source of truth here. ``session.rooms`` is set as an
+        attribute on the socket session and is not guaranteed to survive, so it
+        cannot be relied upon while disconnecting.
+
+        Returns
+        -------
+        list[str]
+            The rooms the client was removed from.
+        """
+        # every client is implicitly in a room named after its own sid
+        left_rooms = [room for room in rooms() if room != request.sid]
+        for room in left_rooms:
             self.__leave_room_and_notify(room)
-
-        auth = db.Authenticatable.get(session.auth_id)
-        auth.status = AuthStatus.OFFLINE.value
-        auth.save()
-
-        # It appears to be necessary to use the root socketio instance
-        # otherwise events cannot be sent outside the current namespace.
-        # In this case, only events to '/tasks' can be emitted otherwise.
-        if session.type == "node":
-            self.log.warning("emitting to /admin")
-            self.socketio.emit("node-status-changed", namespace="/admin")
-            self.__alert_node_status(online=False, node=auth)
-
-            # delete any data on the node stored on the server (e.g.
-            # configuration data)
-            self.__clean_node_data(auth)
-
-        self.log.info(f"{session.name} disconnected")
-
-        # cleanup (e.g. database session)
-        self.__cleanup()
+        return left_rooms
 
     def on_message(self, message: str) -> None:
         """
@@ -375,7 +433,7 @@ class DefaultSocketNamespace(Namespace):
             name of the room the client is leaving
         """
         leave_room(room)
-        msg = f"{session.name} left room {room}"
+        msg = f"{getattr(session, 'name', 'unidentified client')} left room {room}"
         self.log.info(msg)
         self.__notify_room_join_or_leave(room, msg)
 
@@ -392,7 +450,31 @@ class DefaultSocketNamespace(Namespace):
         if room != ALL_NODES_ROOM:
             emit("message", msg, room=room)
 
-    def __alert_node_status(self, online: bool, node: Authenticatable) -> None:
+    @staticmethod
+    def __node_info(node: Authenticatable) -> dict:
+        """
+        Materialize the node fields needed for status events.
+
+        Read these while the instance is still attached to its database session.
+        ``auth.save()`` commits, which expires the attributes, and vantage6's
+        scoped session can be cleared before a later lazy load, which would
+        raise ``DetachedInstanceError`` from inside the disconnect handler.
+
+        Parameters
+        ----------
+        node: Authenticatable
+            The node SQLAlchemy object
+
+        Returns
+        -------
+        dict
+            Plain values describing the node.
+        """
+        return {"id": node.id, "name": node.name, "org_id": node.organization.id}
+
+    def __alert_node_status(
+        self, online: bool, node_info: dict, target_rooms: list[str]
+    ) -> None:
         """
         Send status update of nodes when they change on/offline status
 
@@ -400,14 +482,18 @@ class DefaultSocketNamespace(Namespace):
         ----------
         online: bool
             Whether node is coming online or not
-        node: Authenticatable
-            The node SQLALchemy object
+        node_info: dict
+            Plain node values, materialized while the ORM object was attached
+        target_rooms: list[str]
+            Rooms to send the status update to. Passed in explicitly because on
+            disconnect the client has already left its rooms, and because the
+            socket session cannot be relied upon at that point.
         """
         event = "node-online" if online else "node-offline"
-        for room in session.rooms:
+        for room in target_rooms:
             self.socketio.emit(
                 event,
-                {"id": node.id, "name": node.name, "org_id": node.organization.id},
+                node_info,
                 namespace="/tasks",
                 room=room,
             )

--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
@@ -198,7 +198,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
     this.destroy$.next(true);
     this.nodeStatusUpdateSubscription?.unsubscribe();
   }
-  
+
   shouldShowAllowedValuesDropdown(argument: Argument): boolean {
     return (argument.allowed_values?.length ?? 0) > 0;
   }
@@ -441,7 +441,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
       collaboration_id: this.collaboration?.id || -1,
       databases: taskDatabases,
       store_id: this.algorithm?.algorithm_store_id || -1,
-      server_url: environment.server_url,
+      server_url: `${environment.server_url}${environment.api_path}`,
       organizations: selectedOrganizations.map((organizationID) => {
         return {
           id: Number.parseInt(organizationID),

--- a/vantage6-ui/src/app/pages/analyze/template-task/create/template-task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/template-task/create/template-task-create.component.ts
@@ -30,34 +30,34 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
-    selector: 'app-template-task-create',
-    templateUrl: './template-task-create.component.html',
-    styleUrls: ['./template-task-create.component.scss'],
-    imports: [
-        PageHeaderComponent,
-        MatFormField,
-        MatLabel,
-        MatSelect,
-        ReactiveFormsModule,
-        NgFor,
-        MatOption,
-        NgIf,
-        MatCard,
-        MatCardContent,
-        MatStepper,
-        MatStepperIcon,
-        MatIcon,
-        MatStep,
-        MatStepLabel,
-        MatInput,
-        MatButton,
-        MatStepperNext,
-        DatabaseStepComponent_1,
-        MatStepperPrevious,
-        MatProgressSpinner,
-        AsyncPipe,
-        TranslateModule
-    ]
+  selector: 'app-template-task-create',
+  templateUrl: './template-task-create.component.html',
+  styleUrls: ['./template-task-create.component.scss'],
+  imports: [
+    PageHeaderComponent,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    ReactiveFormsModule,
+    NgFor,
+    MatOption,
+    NgIf,
+    MatCard,
+    MatCardContent,
+    MatStepper,
+    MatStepperIcon,
+    MatIcon,
+    MatStep,
+    MatStepLabel,
+    MatInput,
+    MatButton,
+    MatStepperNext,
+    DatabaseStepComponent_1,
+    MatStepperPrevious,
+    MatProgressSpinner,
+    AsyncPipe,
+    TranslateModule
+  ]
 })
 export class TemplateTaskCreateComponent implements OnInit {
   @HostBinding('class') class = 'card-container';
@@ -233,7 +233,7 @@ export class TemplateTaskCreateComponent implements OnInit {
       image: this.algorithm?.image || '',
       collaboration_id: this.chosenCollaborationService.collaboration$.value?.id || -1,
       store_id: this.algorithm?.algorithm_store_id || -1,
-      server_url: environment.server_url,
+      server_url: `${environment.server_url}${environment.api_path}`,
       databases: taskDatabases,
       organizations: selectedOrganizations.map((organizationID) => {
         return { id: Number.parseInt(organizationID), input: btoa(JSON.stringify(input)) || '' };


### PR DESCRIPTION
# Fix websocket handling that hangs the server and strands nodes

Our 4.15 production server went down on 11 August 2026.
This PR contains the fixes that came out of that investigation.
Scope is 4.15 on Docker only.

There are four code commits.
The first fixes the outage.
The other three fix problems we found while watching the server recover.
A further set of commits adds the documentation page described below.

---

## What broke

The server slowly became unresponsive.
API calls timed out, nodes fell offline, and the log filled up with `Cannot send to sid ...`.
Restarting helped for a while, then it degraded again.

The cause is one line in `websockets.py`.
When a client connects, the server stores the rooms it belongs to on the Flask session:

```python
session.rooms = [...]
```

That attribute is not guaranteed to still be there when the client disconnects.
When it was missing, `on_disconnect` raised `AttributeError`.
And because python-socketio runs our handler *before* it calls `manager.disconnect()`, the crash meant the client was never removed from its rooms.

So the server kept broadcasting to sockets that no longer existed.
Every dead socket made the next broadcast a little more expensive, which starved the eventlet hub, which caused timeouts, which caused more disconnects.

That is why it looks fine for weeks and then falls over quickly: the problem feeds itself.

## Commit 1: fix the disconnect handler

`Fix websocket disconnect handling that could hang the server`

- read the rooms with `rooms()` instead of the session attribute
- accept the `reason` argument that python-socketio passes to `on_disconnect`
- wrap the handler in try/except/finally so cleanup always finishes
- read the node id, name and organisation id *before* `auth.save()`, so a detached SQLAlchemy object cannot break the disconnect path

This commit also makes the node's reconnect backoff configurable (`reconnection_delay_max`, default 60s) so a struggling server is not kept busy by a fleet of reconnecting nodes.

One caveat is documented in `globals.py`. python-socketio's jitter is additive:

```python
delay += randomization_factor * (2 * random() - 1)   # always +/- 0.5s
```

So raising the cap makes a fleet reconnect *less often*, but it never spreads the fleet apart.
Worth knowing if the number of nodes grows.

## Commit 2: stop nodes asking for work that no longer exists

`Stop nodes from retrying runs and requests that cannot succeed`

We saw a node ask for a container token for an already completed task, over and over, forever.

The node already handles a refused token by marking the run as failed, with the comment "To prevent this from happening every time node is restarted".
But the patch it sends leaves out `finished_at`, and the server does this:

```python
run.finished_at = parse_datetime(data.get("finished_at"))   # no key -> NULL
```

The node then asks for work with `state="open"`, which the server translates to `finished_at IS NULL`.
So the run is handed straight back, and the node asks again.
Forever.
The fix is to send `finished_at`.

The proxy had a related problem: it retried *any* status above 210 immediately and without delay, including 4xx responses that will never succeed.
Client errors are now returned to the caller, and server errors wait before a retry.

## Commit 3: superseded, see commit 4

`Disconnect clients whose session the server no longer knows`

**The server-side change in this commit was reverted in commit 4.**
It is kept in the history because the reasoning is useful.
What remains from it is a small node fix: the loop that sends results logged its exceptions and immediately tried again with no pause, so one persistent error became a busy loop.

## Commit 4: let the node reconnect itself

`Reconnect the node websocket instead of pinging a connection that is gone`

After commit 1 was deployed, nodes still got stuck.
They had a live connection, but the server had no session for them, and the log filled with:

```
socketio.server - WARNING - None is not connected to namespace /tasks
```

python-socketio drops those events before any handler runs.
`on_ping` is one of those handlers, and it is the only thing that marks a node online.
So the node stays offline forever.
It does not reconnect either, because as far as it knows it is still connected.

### Two things are wrong on the node

**1.
Nothing ever reconnects.**
There is no watchdog.
The ping worker just skips its ping when the socket is down, and waits for a connection that will never come back.

**2.
The token in the socket headers is frozen.**
The node connects like this:

```python
self.socketIO.connect(url=..., headers=self.client.headers, ...)
```

`headers` is a property that builds a **new** dict each time it is read. python-socketio stores that dict as `connection_headers` and reuses it for every automatic reconnect.
Meanwhile the node keeps refreshing its real token in the background, so the two drift apart.

### The fix

The ping worker now rebuilds the connection when it finds the socket disconnected.
`connect_to_socket()` creates a fresh client with the current token and re-establishes the session, which solves both problems at once.
The old worker then returns, because `connect_to_socket()` starts its own.

Supporting changes:

- `connect_to_socket()` takes `exit_on_failure` and returns a bool.
A failed reconnect now retries on the next cycle instead of killing a running node.
`exit(1)` is still the behaviour on startup.
- the listening loop pauses while the socket is down, because `wait()` returns immediately in that state and the loop would otherwise spin at full speed.

---

## What we tested

We reproduced the stuck-node state with a small flask-socketio server and client on the pinned versions (python-socketio 5.16.4, flask-socketio 5.6.1).
Three results are worth writing down.

**An expired token is not the cause.**
The server emits `expired_token` and returns, but returning `None` from a flask-socketio connect handler *accepts* the connection.
The client gets the event, the namespace connects, pings arrive normally, and the node's existing `on_expired_token` rebuilds the connection.
That path is fine.

**Losing the session server-side reproduces it exactly.**
Pings stop reaching the handler, the warning appears once per event, and the client still believes it is connected.

**Having the server disconnect the client makes it worse.**
That was our first idea, and it is why commit 3 was reverted.
In `socketio/client.py`:

```python
will_reconnect = self.reconnection and self.eio.state == 'connected'
```

A clean close leaves the client engine in state `disconnected`, so it treats the close as final and never comes back.
In our test the client stayed away for the rest of the run.
That is worse than the flood it was meant to stop.

Other checks:

- commit 1 has run in our production server since 11 August, image `server:v4-sio-fix-test`.
API latency stayed around 33 ms and `Cannot send to sid` disappeared completely.
- ruff reports the same number of findings before and after on every file we touched.

---

## Where we stand

We build our own images from this branch into our private ACR.
Four server tags exist right now:

| Tag | Contains | Status |
|---|---|---|
| `v4-sio-fix-test` (`4.15.1-siofix`, `0e4e683`) | commit 1 only | validated, and the safe fallback |
| `v4-sio-fix-test2` (`4.15.1-siofix2`, `0109200b5`) | commits 1-3 | **do not deploy**, contains the reverted approach |
| `v4-sio-fix-temp` (`4.15.1-siotemp`, `da69bce80`) | commit 1-3 plus the first temporary abort | **currently running, and it has a bug**, see below |
| `v4-sio-fix-temp2` (`4.15.1-siotemp2`, `1b066e8e2`) | the same abort, corrected | **deploy this one**, built 11 Aug 17:10 UTC |

Production tags `:4` and `:4.15.1` both still point at digest `388277a4dc92`, the original 4.15.1 image, so a rollback is always one tag change away.

### A page on recognising these loops

Commit 5 adds `docs/server/diagnosing_loops.rst` to the server admin guide.

All four failure modes look identical from the outside, a slow server and nodes
going offline, but they have different causes and different fixes.
The page gives a four-line triage to tell them apart, then per loop: what it
looks like in the log, what causes it, a command that confirms it with a number
rather than an impression, and what fixes it.
It also records the python-socketio reconnect rule that makes a polite
server-side disconnect strand a node for good, which is the single least obvious
thing we learned and the one most likely to be rediscovered the hard way.

It is written to be usable by someone who has never seen the codebase, including
an assistant working from logs alone.

### Exactly how to deploy this, for whoever picks it up

Our central stack is `docker-compose.central.yaml` on the server host, in `vantage6-ops/central-server/`.
The `configs/server.docker-compose.yaml` in that same repo is an **example** and is not what runs.

The relevant containers are:

| Container | Image | Driven by |
|---|---|---|
| `v6-server` | `${REGISTRY}/vantage6/server:${V6_TAG}` | `V6_TAG` in `.env` |
| `v6-ui` | `${REGISTRY}/vantage6/ui:${V6_TAG}` | the same `V6_TAG` |
| `v6-rabbitmq`, `v6-prometheus`, `v6-loki`, `v6-grafana`, `v6-alertmanager`, `v6-control-server` | pinned separately | not affected |

`V6_TAG` defaults to `4.15.1`, so an empty or reverted `.env` silently puts the unfixed image back.
Both `v6-server` and `v6-ui` move together, which is why every one of our test tags covers six images: server, ui, node, alpine and squid, since the node config template ties `alpine` and `squid` to the node tag.

To deploy, set `V6_TAG=v4-sio-fix-temp2` in `.env` next to the compose file and recreate the two containers.
`pull_policy: always` is set, so the new image is fetched on recreate.

Because the guard only acts on a client that has had no session for 30 seconds, the healthy case produces no log noise at all.
What you want to see once is the startup line `Clients without a known session will be disconnected once, after 30 seconds, up to 20 times per 60 seconds`.
If you instead see the same client id being disconnected every few seconds, the guard is not working and `V6_TAG=v4-sio-fix-test` is the safe fallback.

### What we did on 11 August

1. Deployed commit 1 as `v4-sio-fix-test`.
The server recovered immediately:
API latency back to about 33 ms, and `Cannot send to sid` gone entirely.
2. Watched nodes go offline anyway and get stuck in the state described above.
At the low point 9 of our 10 nodes were offline and could not recover.
3. Built `v4-sio-fix-test2` with the disconnect approach, then discarded it after the test showed a clean close stops a client from ever reconnecting.
4. Deployed the temporary abort as `v4-sio-fix-temp`.
All ten nodes re-identified themselves within minutes, without anyone touching a node, and the warnings stopped.
Inference, which had been failing for days, finished in 218 seconds.
5. Wrote the real fix, commit 4, for the node.
6. **That first temporary abort turned out to be broken**, and a few hours later it had taken 9 of 10 nodes offline again.
It removed the socket from `server.eio.sockets` immediately after asking engine.io to close it.
Every later abort attempt on the same client then raised `KeyError` and was swallowed, so the connection was never actually closed and merely had all of its events dropped, pings included.
The symptom in the log is the same client id reappearing every few seconds, forever.
7. Rewrote it as `v4-sio-fix-temp2` with three safeguards: a connection is aborted at most once, only after 30 seconds without a session so a client still completing its handshake is left alone, and the whole guard disables itself if it fires more than 20 times in a minute.
Verified against the reproduction: one abort, one reconnect, 23 pings reaching the handler afterwards, where the broken version looped and delivered none.

### What is running right now, 12 August

`v6-server` runs `v4-sio-fix-temp2`, deployed at 06:28 UTC.
All ten train nodes came back and a training task ran to completion on it.

The corrected guard behaves as intended in production: it fired **once**, at 07:47:33, and never again.
No repeated client id, no circuit breaker, no errors and no tracebacks in two hours of DEBUG logs.
Room join and leave are both logged for every connection, so commit 1 is doing its work.

Nodes still run stock 4.15.1, so commits 2 and 4 are not in effect anywhere yet.

### A second mass drop, and why this PR would not have prevented it

Later the same morning all ten train nodes went offline again, between 07:40:50 and 07:46:50.
This is worth writing down because it says something about the limits of these fixes.

The server was healthy throughout, answering `/api/version` in about 30 ms.
The nodes left one at a time over six minutes, which is a ping-timeout cascade rather than the server dropping them.
The window began about two minutes after a training task completed, while its results were being collected and pushed to blob storage, which is the same correlation as the original outage and the first time we have it with timestamps.

Then the useful part.
In the two hours that followed, **not one train node made a single request**: no login attempt, no `state=open` poll, and not one websocket event the server had to reject.
A test node on the same server connected and worked normally in that same window.

That rules out a ghost session, and it rules out this PR as a remedy:

- the server-side half is event driven, so it only acts because a node sent something;
- the node-side half needs the node process to be running.

**Every recovery path here is reactive.** Neither half reaches a node that has stopped.
Getting these nodes back needs a restart at the hospitals; nothing on the server can do it.

This does not change the fixes, but it does bound the claim made for them.

### Docs: two additions from the above

`docs/server/diagnosing_loops.rst` grew three sections that came out of this:

- **how to date a mass drop** using `last_seen`, and what the spread means: within seconds the server dropped them, over minutes a ping-timeout cascade, hours apart is not one incident;
- **silence as a diagnosis**, with a table separating "node alive, websocket broken" from "ghost session" from "node not running", because the absence of traffic is a stronger signal than the presence of errors;
- **the four-step chain** showing that the ghost-session fix only works with both halves deployed, and precisely which link breaks if you ship only one.

### About the stuck nodes

Commit 4 fixes the node, which means it does nothing for a node that is already stuck.
To get ours back without visiting ten hospitals, we deployed a temporary server-side measure from the branch `temp/socketio-abort-unknown-session` (image `v4-sio-fix-temp`).
It aborts the connection of a client that has no session, so the client sees a broken connection rather than a polite goodbye and does reconnect.

It is deliberately **not part of this PR**: it wraps the private `_handle_event` and reaches into engine.io internals.
It should be removed once the nodes run commit 4.
If a supported server-side equivalent is wanted, that is a separate discussion.

## Still open

- **Nodes need a redeploy** before commits 2 and 4 do anything.
Ours still run stock 4.15.1.
Until they are updated the temporary server-side guard is the only thing that can rescue a stuck node, so it cannot be rolled back on its own.
- **The temporary guard is a stopgap and should not outlive this PR.**
It wraps the private `_handle_event` and reaches into engine.io internals, and it already caused one outage of its own when the first version was wrong.
It exists because we cannot redeploy ten hospital nodes on demand.
- **We still do not know what triggered the original stall.**
  The mass disconnect coincided with `uwsgi-websocket: no PONG received in 3 seconds` and multi-megabyte blob transfers at the same moment.
Our unverified hypothesis is that synchronous blob I/O blocks the worker long enough for websocket pings to time out.
Commit 1 makes the server survive this; it does not remove the cause.
- **The server logs at DEBUG and includes full algorithm input and output.**
  A privacy concern, unrelated to this PR, that should be dealt with separately.
- **Orphaned algorithm containers are invisible after a node restart**, because `cleanup_tasks()` iterates the in-memory `active_tasks`.
Neither a restart nor `task.kill()` clears them, only `docker rm -f` on the host.
Tracked separately.
- Upstream issue #2386 describes the same stuck-node symptom.

## Note for the reviewer

This branch also carries two commits that are not ours (`5c13ba98b` and `a83503df7`, a UI hotfix for the server URL in POST task).
They came with the base the branch was cut from.
Everything in `vantage6-node/` and `vantage6-server/` is ours; the changes under the UI directory are not.


